### PR TITLE
fix: validate Apple Silicon and account-selected model defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Recognize Apple Silicon macOS as live-verified, with tested versions and live coverage recorded in `DEVELOPING.md`.
+
+### Fixed
+
+- Treat `default` as Claude Code's account-selected model in live validation instead of pinning it to Sonnet, and keep its Pro context limit at the same conservative 200K as Opus.
+- Isolate paid validation from personal Pi settings, extensions, skills, and context files without moving user files or weakening the provider's prompt-size limit.
+- Resolve npm Pi installations whose CLI lives in `dist/bundle/cli.js`, checking package identities before using a candidate directory.
+
 ## [0.1.4] - 2026-08-23
 
 ### Fixed

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -12,7 +12,7 @@ npm test
 
 Do not run `npm install` at the repository root. The package has no installed dependencies and must not contain root `node_modules` or a root lockfile. `setup:dev` installs the isolated, locked `tooling/` package containing the TypeScript parser/compiler and Node declarations used by source-policy checks and typechecking. Its ignored `node_modules/` is generated development state, not published runtime code. Pi loads the TypeScript extension directly; there is no runtime build.
 
-When npm and standalone Pi installations coexist, development uses whichever `pi` resolves first on `PATH`. Put the npm installation's bin directory first for `npm run check` and `npm test`; verify it with `command -v pi` on POSIX or `where pi` on Windows. Keep the development host npm-based, and use `PI_CLAUDE_CODE_PROVIDER_PI_BIN` only to select a standalone executable for the live bridge lane.
+When npm and standalone Pi installations coexist, development uses whichever `pi` resolves first on `PATH`. Put the npm installation's bin directory first for `npm run check` and `npm test`; verify it with `command -v pi` on POSIX or `where pi` on Windows. Keep the development host npm-based, and use `PI_CLAUDE_CODE_PROVIDER_PI_BIN` only to select a standalone executable for the live bridge lane. The resolver recognizes both `dist/cli.js` and `dist/bundle/cli.js` npm layouts and checks package identities. Resolving a newer layout does not establish version compatibility: if that installation's exported modules have missing dependencies, use an isolated npm installation of the verified Pi version rather than modifying the global install.
 
 To load a local checkout:
 
@@ -40,20 +40,33 @@ Pi remains authoritative for prepared context, branches, compaction, active tool
 
 | Component | Verified baseline |
 | --- | --- |
-| Pi | 0.84.2, npm distribution; standalone tar.gz build live-verified on Linux x64 only |
-| Claude Code | 2.1.241 |
-| Node.js | 24.16.0 on WSL2 and Apple Silicon macOS CI; 22.23.1 on Windows |
-| Platform | WSL2 Ubuntu/Linux x64; native Windows x64; GitHub-hosted Apple Silicon macOS deterministic CI |
+| Pi | 0.84.2, npm distribution; standalone tar.gz bridge live-verified on Linux x64 and Apple Silicon macOS |
+| Claude Code | 2.1.241; additionally 2.1.260 in the Apple Silicon validation below |
+| Node.js | 24.16.0 on WSL2 and Apple Silicon macOS CI; 22.23.1 on Windows; 25.9.0 in Apple Silicon live validation |
+| Platform | WSL2 Ubuntu/Linux x64; native Windows x64; Apple Silicon macOS 26.5 (arm64) |
 
 Pi's distribution is part of the baseline, not an implementation detail: the npm build runs on Node and the standalone tar.gz build is a compiled Bun binary, and `process.execPath` means something different on each. `src/host-runtime.ts` owns that difference in one place (`scriptLaunch`), which sets `BUN_BE_BUN=1` so a compiled Pi binary runs the proposal bridge instead of its own embedded entry point, and pins `--config=` to a neutral `bunfig.toml` in the private request directory. Pi compiles with `--no-compile-autoload-bunfig`, but that protects Pi's own entry point only and does not survive `BUN_BE_BUN`; without the pin, a `bunfig.toml` in the bridge's working directory preloads code into it. Only the joined `--config=` form works, as Bun ignores a space-separated one and then consumes the script path. The mechanism is not Linux-specific: Pi builds all six standalone targets from one `bun build --compile` invocation, and `BUN_BE_BUN` is part of the embedded Bun runtime on each. Record a standalone baseline only after `npm run test:paid:bridge-standalone` passes against that exact build.
 
-Apple Silicon macOS passes the [deterministic GitHub Actions matrix](.github/workflows/ci.yml); subscription-consuming live Claude validation on macOS remains pending. Other platforms and versions continue with advisory warnings, while protocol and isolation mismatches fail closed. Supported effort values are `low`, `medium`, `high`, `xhigh`, and `max`; Pi `off` and `minimal` are hidden.
+Apple Silicon macOS passes the [deterministic GitHub Actions matrix](.github/workflows/ci.yml) and has live coverage for the release stages described below. Other platforms and versions continue with advisory warnings, while protocol and isolation mismatches fail closed. Supported effort values are `low`, `medium`, `high`, `xhigh`, and `max`; Pi `off` and `minimal` are hidden.
+
+### Apple Silicon live validation
+
+Verified on 2026-09-05 with macOS 26.5/arm64, Claude Code 2.1.260, Node 25.9.0, and Pi 0.84.2:
+
+- Text, tools, images, isolation, recovery, Unicode, history, and web search.
+- Prompt-cache reuse of 99.3% and 99.0% on subsequent turns.
+- Tool bridge round trips through both npm Pi and the macOS arm64 standalone build.
+- All 20 blocking model/effort combinations. The account default selected Opus 5 at all five effort levels.
+
+The model matrix passes with personal skills left in place. Fable remains outside the blocking matrix. The verified Pi baseline remains 0.84.2.
 
 ## Validation
 
 `npm run check` enforces dependency and import policy, Markdown links and versions, source boundaries, JavaScript syntax, and strict TypeScript. `npm test` runs deterministic tests. Neither command performs Claude inference or consumes subscription quota; `check` may run `claude --version` for advisory metadata.
 
 Subscription-consuming commands are named `test:paid:*`. They show the detected subscription, request caps, and quota/spend warning, then require the exact phrase `USE PAID CLAUDE QUOTA`. Noninteractive execution additionally requires `PI_CLAUDE_CODE_PROVIDER_CONFIRM_PAID_TESTS=1`. The underlying scripts refuse direct invocation, perform no automatic retries, and atomically claim a stage and aggregate slot before every provider or web-search Claude launch.
+
+The runner gives Pi a temporary agent directory and disables automatic extension, skill, context-file, and prompt-template loading. Only the explicitly selected provider package is loaded. Both controls matter: `PI_CODING_AGENT_DIR` alone does not suppress `~/.agents/skills`. Keep personal skill directories in place; tests must not depend on moving them. Claude subscription authentication and organization-managed policy remain available.
 
 | Command | Maximum Claude launches |
 | --- | ---: |
@@ -73,6 +86,8 @@ Subscription-consuming commands are named `test:paid:*`. They show the detected 
 Both bridge lanes are required, and `test:paid:release` runs both. A `--no-tools` turn passes even when the proposal bridge never starts, so only a turn that actually round-trips a tool distinguishes a working bridge from a broken one. `/pi-claude-code-provider-doctor` performs the same handshake without consuming quota.
 
 The release suite covers text, tool, image, isolation, recovery, Unicode, history, web search, cache reuse, both bridge lanes, the gated aliases, and the supported effort matrix. Fable is technically selectable, but validating it on Pro consumes separate paid credits rather than the included subscription allocation, so it is deliberately excluded from the release matrix; the blocking Sonnet and Opus cases already exercise the shared transport. `npm run test:paid:fable` remains an opt-in one-launch case for a maintainer who separately authorizes that spend. Successful RPC harnesses close stdin so Pi can run session shutdown and flush metrics before exit.
+
+The model matrix pins verified identities for explicit aliases, but `default` delegates to Claude Code's account runtime default. For that entry it requires a concrete Claude model identity instead of assuming Sonnet or Opus. All entries still check context/output capabilities, cleanup, and the absence of leaked private directories. Pro's `default` and `opus` entries retain the conservative 200K context limit.
 
 Each request serializes the complete current transcript. Cache-hit percentage is `cacheRead / (input + cacheRead + cacheWrite) * 100`; cache writes seed later reuse and are not hits. Preserve append-stable history blocks and sorted tool catalogs when changing serialization. Claude Code 2.1.233 introduced a changing `<total_tokens>` reminder that broke reuse across fresh print-mode processes; the provider pins `totalTokensReminder: "off"` following [bcherny's maintainer guidance](https://github.com/anthropics/claude-code/issues/81259#issuecomment-5311888970). The setting is otherwise undocumented, so do not remove it without a replacement cache probe and new upstream guidance.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project was developed using frontier AI models under human guidance. Almost
 - Claude Code logged in to an eligible Pro, Max, Team, or Enterprise claude.ai subscription
 - Node.js 22.19 or newer only when Pi itself is installed from npm; the standalone build needs no separate Node installation
 
-Pi ships as an npm package that runs on Node and as a compiled standalone binary that embeds Bun. Both are supported: the package launches its tool-proposal bridge under whichever runtime is hosting Pi rather than assuming Node. The standalone build carries its own live gate, which has passed on Linux x64; the table in [DEVELOPING.md](DEVELOPING.md#compatibility-baseline) records the exact scope. Run `/pi-claude-code-provider-doctor` on either build: it reports the resolved runtime and completes a real bridge handshake.
+Pi ships as an npm package that runs on Node and as a compiled standalone binary that embeds Bun. Both are supported: the package launches its tool-proposal bridge under whichever runtime is hosting Pi rather than assuming Node. The standalone build carries its own live bridge gate, which has passed on Linux x64 and Apple Silicon macOS; the table in [DEVELOPING.md](DEVELOPING.md#compatibility-baseline) records the exact scope. Run `/pi-claude-code-provider-doctor` on either build: it reports the resolved runtime and completes a real bridge handshake.
 
 See the [compatibility baseline](DEVELOPING.md#compatibility-baseline) for tested versions and platforms. Other platforms continue with a warning and runtime capability checks.
 
@@ -45,7 +45,9 @@ To select one directly:
 
 The same canonical reference works from the command line with `pi --model pi-claude-code-provider/sonnet`.
 
-Pi maps its exposed thinking levels to Claude's `low`, `medium`, `high`, `xhigh`, and `max` effort values; unsupported levels are hidden. Opus uses a 200K context window on Pro and 1M on Max, Team, and Enterprise. The provider retains 200K on Pro even when Claude Code reports a 1M-capable variant, because it cannot determine credit availability.
+`default` leaves model selection to Claude Code's [account runtime default](https://code.claude.com/docs/en/model-config#default-model-setting); it is not a synonym for Sonnet. Personal model settings and environment overrides are suppressed by this provider, while organization-managed policy can still apply. Select `sonnet` or `opus` explicitly when the model family matters.
+
+Pi maps its exposed thinking levels to Claude's `low`, `medium`, `high`, `xhigh`, and `max` effort values; unsupported levels are hidden. Opus uses a 200K context window on Pro and 1M on Max, Team, and Enterprise. The provider retains 200K on Pro even when Claude Code reports a 1M-capable variant, because it cannot determine credit availability. The `default` entry uses the same conservative Pro limit because it can select Opus; explicit `sonnet` retains its 1M window.
 
 The `fable` alias is offered and separately testable, but it is excluded from the paid release gate. Fable 5 availability, included allocation, and billing vary by subscription tier. It otherwise follows the standard alias path wherever the account allows it. See Anthropic's [Fable plan policy](https://support.claude.com/en/articles/15424964-claude-fable-5-on-your-plan).
 

--- a/scripts/lib/model-matrix-policy.js
+++ b/scripts/lib/model-matrix-policy.js
@@ -1,7 +1,19 @@
+import { EXPECTED_MODEL_RESOLUTIONS } from "../../src/compatibility.ts";
+
+export function resolvedModelMatches(modelId, servedModel) {
+  const expected = EXPECTED_MODEL_RESOLUTIONS[modelId];
+  // A dynamic default must still report a concrete Claude identity. Capacity,
+  // output limits, and cleanup are checked independently by the live matrix.
+  if (expected === null) {
+    return typeof servedModel === "string" && /^claude-[a-z0-9][a-z0-9.-]*$/.test(servedModel) && !/\s/.test(servedModel);
+  }
+  return typeof expected === "string" && servedModel === expected;
+}
+
 export function servedContextWindowMatches(subscriptionType, modelId, configuredContextWindow, servedContextWindow) {
   // Claude Code may report the 1M-capable Opus variant on Pro even when the
   // account has no usage credits. Keep Pi's safe configured limit at 200K.
-  if (subscriptionType === "pro" && modelId === "opus" && configuredContextWindow === 200_000) {
+  if (subscriptionType === "pro" && (modelId === "opus" || modelId === "default") && configuredContextWindow === 200_000) {
     return servedContextWindow === 200_000 || servedContextWindow === 1_000_000;
   }
   return servedContextWindow === configuredContextWindow;

--- a/scripts/lib/pi-installation.js
+++ b/scripts/lib/pi-installation.js
@@ -24,8 +24,8 @@ export function findOnPath(name) {
 function firstPackageRoot(candidates, name) {
   for (const candidate of candidates) {
     try {
-      readFileSync(join(candidate, "package.json"));
-      return candidate;
+      const manifest = JSON.parse(readFileSync(join(candidate, "package.json"), "utf8"));
+      if (manifest.name === (name === "typebox" ? name : `@earendil-works/${name}`)) return candidate;
     } catch {
       // Try the next layout supported by npm's global installer.
     }
@@ -92,6 +92,8 @@ function resolvePiPackages(piCli) {
       join(shimDirectory, "node_modules", "@earendil-works", "pi-coding-agent"),
       // A normal npm global bin symlink resolves to <package>/dist/cli.js.
       dirname(dirname(piCli)),
+      // Pi 0.85 also ships the npm entry at <package>/dist/bundle/cli.js.
+      dirname(dirname(dirname(piCli))),
     ],
     "pi-coding-agent",
   );
@@ -126,6 +128,14 @@ export function piLaunch(args = []) {
   return /\.[cm]?js$/i.test(override)
     ? { command: process.execPath, args: [override, ...args] }
     : { command: override, args: [...args] };
+}
+
+/** Live validation must not discover personal skills, context, or executable extensions. */
+export function livePiLaunch(args = []) {
+  return piLaunch([
+    "--no-extensions", "--no-skills", "--no-context-files", "--no-prompt-templates",
+    ...args,
+  ]);
 }
 
 /** Read and validate the launcher override, so a typo fails by name rather than as ENOENT at spawn. */

--- a/scripts/live-test.js
+++ b/scripts/live-test.js
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { deflateSync } from "node:zlib";
 import { closeLiveRpcProcess, consumeJsonl, superviseLiveProcess } from "./lib/live-process.js";
-import { describePiLaunch, piLaunch } from "./lib/pi-installation.js";
+import { describePiLaunch, livePiLaunch } from "./lib/pi-installation.js";
 if (process.env.PI_CLAUDE_CODE_PROVIDER_PAID_TEST_CHILD !== "1") {
     throw new Error("Paid live tests must be started through an npm test:paid:* script");
 }
@@ -103,8 +103,8 @@ async function runCacheProbe(cwd) {
 }
 async function runProviderJourney(cwd) {
     const rpc = openPiRpc(cwd, [
-        "--mode", "rpc", "--no-session", "--no-extensions", "-e", packageRoot,
-        "--no-skills", "--no-context-files", "--provider", "pi-claude-code-provider",
+        "--mode", "rpc", "--no-session", "-e", packageRoot,
+        "--provider", "pi-claude-code-provider",
         "--model", "sonnet:medium", "--tools", "read,write",
     ], "Pi provider journey");
     let completed = false;
@@ -179,7 +179,7 @@ function openPiRpc(cwd, args, label) {
     return { turn, close };
 }
 function spawnPi(args, options) {
-    const launch = piLaunch(args);
+    const launch = livePiLaunch(args);
     return spawn(launch.command, launch.args, {
         ...options,
         detached: process.platform !== "win32",

--- a/scripts/model-matrix.js
+++ b/scripts/model-matrix.js
@@ -7,8 +7,8 @@ import { EXPECTED_MODEL_RESOLUTIONS } from "../src/compatibility.ts";
 import { inspectClaudeInstallation } from "../src/auth.ts";
 import { providerModelsForSubscription } from "../src/catalog.ts";
 import { consumeJsonl, superviseLiveProcess } from "./lib/live-process.js";
-import { piLaunch } from "./lib/pi-installation.js";
-import { servedContextWindowMatches } from "./lib/model-matrix-policy.js";
+import { livePiLaunch } from "./lib/pi-installation.js";
+import { resolvedModelMatches, servedContextWindowMatches } from "./lib/model-matrix-policy.js";
 
 if (process.env.PI_CLAUDE_CODE_PROVIDER_PAID_TEST_CHILD !== "1") {
     throw new Error("The paid model matrix must be started through an npm test:paid:* script");
@@ -45,7 +45,7 @@ const selectedCases = selectedCase ? selectableCases.filter(({ model, effort }) 
 async function runCase(cwd, model, effort) {
     const metricsBefore = await metricsEntries();
     const runtimeBefore = await runtimeDirectories();
-    const launch = piLaunch([
+    const launch = livePiLaunch([
         "--no-session", "-e", packageRoot, "--provider", "pi-claude-code-provider", "--model", `${model}:${effort}`,
         "--no-tools", "--mode", "json", "Reply exactly OK.",
     ]);
@@ -87,7 +87,7 @@ async function runCase(cwd, model, effort) {
     if (!message) throw new Error(`${model}:${effort} returned no assistant message`);
     const text = message.content.filter((block) => block.type === "text").map((block) => block.text).join("").trim();
     assert.match(text, /^OK\.?$/, `${model}:${effort} response text`);
-    assert.equal(message.responseModel, EXPECTED_MODEL_RESOLUTIONS[model], `${model}:${effort} resolved model`);
+    assert.ok(resolvedModelMatches(model, message.responseModel), `${model}:${effort} unexpected resolved model: ${message.responseModel}`);
     const metrics = await waitForMetrics(metricsBefore.length, model, effort);
     const configured = providerModels.find((entry) => entry.id === model);
     assert.equal(metrics.cleanupComplete, true, `${model}:${effort} private-state cleanup`);
@@ -96,7 +96,7 @@ async function runCase(cwd, model, effort) {
         true,
         `${model}:${effort} served context window`,
     );
-    if (installation.subscriptionType === "pro" && model === "opus") {
+    if (installation.subscriptionType === "pro" && (model === "opus" || model === "default")) {
         assert.equal(configured.contextWindow, 200_000, `${model}:${effort} safe configured context window`);
     }
     assert.equal(metrics.servedMaxOutputTokens, configured.maxTokens, `${model}:${effort} served maximum output`);

--- a/scripts/paid-test-runner.js
+++ b/scripts/paid-test-runner.js
@@ -68,17 +68,21 @@ if (confirmationMode === "environment") {
 
 const directory = await mkdtemp(join(tmpdir(), "pi-claude-code-provider-paid-"));
 const metricsLog = join(directory, "metrics.jsonl");
+const agentDirectory = join(directory, "pi-agent");
 const aggregateBudgetDirectory = join(directory, "aggregate-budget");
 await mkdir(aggregateBudgetDirectory);
 let observed = 0;
 
 try {
+  await mkdir(agentDirectory);
   for (const [stageIndex, stage] of planned.entries()) {
     const stageBudgetDirectory = join(directory, `stage-${stageIndex + 1}-budget`);
     await mkdir(stageBudgetDirectory);
     const before = await metricCount(metricsLog);
     await run(stage.script, stage.args, {
       ...process.env,
+      PI_CODING_AGENT_DIR: agentDirectory,
+      PI_OFFLINE: "1",
       // Lanes are explicit: an ambient override must not silently redirect the
       // npm lane, and the standalone lane must not fall back to the npm entry.
       ...(stage.requiresPiBin ? {} : { [PI_BIN_ENV]: "" }),

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -33,7 +33,8 @@ function providerModel(
 export function providerModelsForSubscription(subscriptionType: ClaudeSubscriptionType): ProviderModelConfig[] {
   const opusContextWindow = subscriptionType === "pro" ? 200_000 : 1_000_000;
   return [
-    providerModel("default", "Claude Code Default", 1_000_000, 64_000),
+    // The account default can select Opus; retain the same Pro safety bound.
+    providerModel("default", "Claude Code Default", opusContextWindow, 64_000),
     providerModel("sonnet", "Claude Code Sonnet", 1_000_000, 64_000),
     providerModel("fable", "Claude Code Fable", 1_000_000, 64_000),
     providerModel("opus", "Claude Code Opus", opusContextWindow, 64_000),

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -5,10 +5,11 @@ export const VERIFIED_VERSIONS = Object.freeze({
   claudeCode: "2.1.241",
 });
 
-const VERIFIED_PLATFORMS = "WSL2 Ubuntu/linux-x64; native Windows/win32-x64";
+const VERIFIED_PLATFORMS = "WSL2 Ubuntu/linux-x64; native Windows/win32-x64; Apple Silicon macOS/darwin-arm64";
 
 export const EXPECTED_MODEL_RESOLUTIONS = Object.freeze({
-  default: "claude-sonnet-5",
+  // No --model override: Claude selects the account's runtime default.
+  default: null,
   sonnet: "claude-sonnet-5",
   fable: "claude-fable-5",
   opus: "claude-opus-5",
@@ -66,7 +67,7 @@ export function platformStatus(
       current,
       verified: VERIFIED_PLATFORMS,
       isVerified: false,
-      warning: `${current} is a compatibility candidate; the verified platform baselines are WSL2 Ubuntu/linux-x64 and native Windows/win32-x64`,
+      warning: `${current} is a compatibility candidate; the verified platform baselines are ${VERIFIED_PLATFORMS}`,
     };
   }
   if (platform === "darwin" && architecture === "arm64") {
@@ -74,8 +75,7 @@ export function platformStatus(
       component: "Platform",
       current,
       verified: VERIFIED_PLATFORMS,
-      isVerified: false,
-      warning: "Apple Silicon macOS is a compatibility candidate; deterministic CI passes, but subscription-consuming live validation is pending",
+      isVerified: true,
     };
   }
   return {

--- a/test/unit/catalog.test.js
+++ b/test/unit/catalog.test.js
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { providerModelsForSubscription } from "../../src/catalog.ts";
 
-test("derives only the Opus context window from the subscription type", () => {
+test("keeps Pro default and Opus within the safe context window", () => {
     for (const subscriptionType of ["pro", "max", "team", "enterprise"]) {
         const models = providerModelsForSubscription(subscriptionType);
         assert.deepEqual(
             models.map(({ id, name, contextWindow, maxTokens }) => ({ id, name, contextWindow, maxTokens })),
             [
-                { id: "default", name: "Claude Code Default", contextWindow: 1_000_000, maxTokens: 64_000 },
+                { id: "default", name: "Claude Code Default", contextWindow: subscriptionType === "pro" ? 200_000 : 1_000_000, maxTokens: 64_000 },
                 { id: "sonnet", name: "Claude Code Sonnet", contextWindow: 1_000_000, maxTokens: 64_000 },
                 { id: "fable", name: "Claude Code Fable", contextWindow: 1_000_000, maxTokens: 64_000 },
                 { id: "opus", name: "Claude Code Opus", contextWindow: subscriptionType === "pro" ? 200_000 : 1_000_000, maxTokens: 64_000 },

--- a/test/unit/claude-args.test.js
+++ b/test/unit/claude-args.test.js
@@ -35,6 +35,15 @@ test("uses only generated attachment references and replacement prompt", () => {
     ]);
 });
 
+test("default delegates model selection to Claude while explicit aliases stay explicit", () => {
+    const prepared = { transcriptBlocks: [], attachmentPaths: [], systemPromptPath: "/tmp/system.txt" };
+    assert.equal(providerArgs(prepared, "default", "low").args.includes("--model"), false);
+    for (const model of ["sonnet", "opus", "haiku", "fable"]) {
+        const { args } = providerArgs(prepared, model, "low");
+        assert.equal(args[args.indexOf("--model") + 1], model);
+    }
+});
+
 test("pins cache-stable Claude settings and omits fixed outer guidance", () => {
     const args = baseClaudeArgs();
     const settings = JSON.parse(args[args.indexOf("--settings") + 1]);

--- a/test/unit/compatibility.test.js
+++ b/test/unit/compatibility.test.js
@@ -8,8 +8,9 @@ test("verified versions report verified status without a warning", () => {
   assert.equal(status.warning, undefined);
 });
 
-test("defines concrete compatibility targets for every picker alias", () => {
+test("distinguishes the account default from pinned alias compatibility targets", () => {
   assert.deepEqual(Object.keys(EXPECTED_MODEL_RESOLUTIONS), ["default", "sonnet", "fable", "opus", "haiku"]);
+  assert.equal(EXPECTED_MODEL_RESOLUTIONS.default, null);
   assert.equal(EXPECTED_MODEL_RESOLUTIONS.opus, "claude-opus-5");
   assert.match(EXPECTED_MODEL_RESOLUTIONS.haiku, /^claude-haiku-/);
 });
@@ -27,8 +28,9 @@ test("reports verified and candidate platforms accurately", () => {
   assert.equal(platformStatus("linux", "x64", "6.8.0-generic").isVerified, false);
   assert.equal(platformStatus("linux", "arm64", "6.6-microsoft-standard-WSL2", "Ubuntu").isVerified, false);
   const macos = platformStatus("darwin", "arm64");
-  assert.equal(macos.isVerified, false);
-  assert.match(macos.warning, /Apple Silicon.*deterministic CI passes.*live validation is pending/);
+  assert.equal(macos.isVerified, true);
+  assert.equal(macos.warning, undefined);
+  assert.match(macos.verified, /Apple Silicon macOS\/darwin-arm64/);
   assert.match(platformStatus("darwin", "x64").warning, /unverified/);
   const windows = platformStatus("win32", "x64");
   assert.equal(windows.isVerified, true);

--- a/test/unit/model-matrix-policy.test.js
+++ b/test/unit/model-matrix-policy.test.js
@@ -1,11 +1,30 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { servedContextWindowMatches } from "../../scripts/lib/model-matrix-policy.js";
+import { resolvedModelMatches, servedContextWindowMatches } from "../../scripts/lib/model-matrix-policy.js";
+
+test("the account default accepts concrete model identities without pinning a family", () => {
+    assert.equal(resolvedModelMatches("default", "claude-sonnet-5"), true);
+    assert.equal(resolvedModelMatches("default", "claude-opus-5"), true);
+    for (const value of [undefined, null, "", "default", "opus", "not-a-model", "claude-opus-5\n"]) {
+        assert.equal(resolvedModelMatches("default", value), false);
+    }
+});
+
+test("explicit aliases still require their verified model and unknown aliases fail", () => {
+    assert.equal(resolvedModelMatches("sonnet", "claude-sonnet-5"), true);
+    assert.equal(resolvedModelMatches("sonnet", "claude-opus-5"), false);
+    assert.equal(resolvedModelMatches("opus", "claude-opus-5"), true);
+    assert.equal(resolvedModelMatches("opus", "claude-sonnet-5"), false);
+    assert.equal(resolvedModelMatches("unknown", undefined), false);
+});
 
 test("keeps Pro Opus configured at 200K while tolerating Claude's 1M capability report", () => {
     assert.equal(servedContextWindowMatches("pro", "opus", 200_000, 200_000), true);
     assert.equal(servedContextWindowMatches("pro", "opus", 200_000, 1_000_000), true);
     assert.equal(servedContextWindowMatches("pro", "opus", 200_000, 500_000), false);
+    assert.equal(servedContextWindowMatches("pro", "default", 200_000, 200_000), true);
+    assert.equal(servedContextWindowMatches("pro", "default", 200_000, 1_000_000), true);
+    assert.equal(servedContextWindowMatches("pro", "default", 200_000, 500_000), false);
     assert.equal(servedContextWindowMatches("pro", "sonnet", 1_000_000, 200_000), false);
     assert.equal(servedContextWindowMatches("max", "opus", 1_000_000, 200_000), false);
     assert.equal(servedContextWindowMatches("max", "opus", 1_000_000, 1_000_000), true);

--- a/test/unit/paid-runner-lifecycle.test.js
+++ b/test/unit/paid-runner-lifecycle.test.js
@@ -14,7 +14,7 @@ import { spawn } from "node:child_process";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 
-async function fakeClaude(directory) {
+async function fakeClaude(directory, reply = "OK") {
   const executable = join(directory, process.platform === "win32" ? "claude.cjs" : "claude");
   const init = { type: "system", subtype: "init", tools: [], mcp_servers: [], model: "claude-sonnet-5", permissionMode: "dontAsk", slash_commands: [], skills: [], plugins: [], apiKeySource: "none" };
   // This fake CLI must not rely on buffered child stdout in restricted sandboxes.
@@ -23,16 +23,55 @@ if (process.argv.includes("--version")) process.stdout.write(${JSON.stringify(`$
 else if (process.argv[2] === "auth" && process.argv[3] === "status") process.stdout.write(JSON.stringify(${JSON.stringify(ELIGIBLE_CLAUDE_AUTH)}));
 else if (process.argv.includes("--help")) process.stdout.write(${JSON.stringify(CLAUDE_HEADLESS_HELP)});
 else {
+  const systemPath = process.argv[process.argv.indexOf("--system-prompt-file") + 1];
+  if (systemPath && require("node:fs").readFileSync(systemPath, "utf8").includes("AMBIENT_ISOLATION_MARKER")) {
+    process.stderr.write("Ambient system prompt reached the fake provider");
+    process.exit(93);
+  }
   process.stdin.resume();
   process.stdin.on("end", () => {
     process.stdout.write(JSON.stringify(${JSON.stringify(init)}) + "\\n");
-    process.stdout.write(JSON.stringify({type:"result",is_error:false,result:"OK"}) + "\\n");
+    process.stdout.write(JSON.stringify({type:"result",is_error:false,result:${JSON.stringify(reply)}}) + "\\n");
   });
 }
 `), { mode: 0o700 });
   await chmod(executable, 0o700);
   return executable;
 }
+
+test("the guarded runner isolates ambient SYSTEM.md without changing the user's config", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pi-paid-isolation-fixture-"));
+  const agentDirectory = join(directory, "agent");
+  await mkdir(agentDirectory);
+  const systemFile = join(agentDirectory, "SYSTEM.md");
+  await writeFile(systemFile, "AMBIENT_ISOLATION_MARKER");
+  const executable = await fakeClaude(directory, "live test successful");
+  const child = spawn(process.execPath, nodeFixtureArgs([join(root, "scripts", "paid-test-runner.js"), "smoke"]), {
+    cwd: root,
+    detached: process.platform !== "win32",
+    windowsHide: process.platform === "win32",
+    env: {
+      ...process.env,
+      PI_CODING_AGENT_DIR: agentDirectory,
+      PI_OFFLINE: "1",
+      PI_CLAUDE_CODE_PROVIDER_PATH: executable,
+      PI_CLAUDE_CODE_PROVIDER_CONFIRM_PAID_TESTS: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const supervisor = superviseLiveProcess(child, { timeoutMs: 20_000, label: "isolated paid smoke fixture" });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { output += chunk; });
+  try {
+    assert.deepEqual(await supervisor.wait(), { code: 0, signal: null }, output);
+    assert.match(output, /recorded 1\/1; aggregate 1\/1/);
+    assert.equal(await readFile(systemFile, "utf8"), "AMBIENT_ISOLATION_MARKER");
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) await supervisor.terminate();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("paid RPC accounting flushes one metric for every claim before graceful exit", async () => {
   const directory = await mkdtemp(join(tmpdir(), "pi-claude-code-provider-paid-rpc-lifecycle-"));

--- a/test/unit/pi-installation.test.js
+++ b/test/unit/pi-installation.test.js
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { realpathSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
-import { isCompiledPi, locatePiPackages, piCliEntry } from "../../scripts/lib/pi-installation.js";
+import { isCompiledPi, livePiLaunch, locatePiPackages, piCliEntry } from "../../scripts/lib/pi-installation.js";
 
 test("locates Pi packages in the bundled Windows-installer layout", async () => {
   const prefix = await mkdtemp(join(tmpdir(), "pi-installation-layout-"));
@@ -36,6 +36,31 @@ test("locates Pi packages in the bundled Windows-installer layout", async () => 
   }
 });
 
+test("locates an npm CLI in dist/bundle without accepting an unrelated manifest", { skip: process.platform === "win32" }, async () => {
+  const prefix = await mkdtemp(join(tmpdir(), "pi-installation-bundle-"));
+  const codingAgent = join(prefix, "node_modules", "@earendil-works", "pi-coding-agent");
+  const bin = join(prefix, "bin");
+  const entry = join(codingAgent, "dist", "bundle", "cli.js");
+  const originalPath = process.env.PATH;
+  try {
+    await Promise.all([bin, dirname(entry), join(codingAgent, "node_modules", "@earendil-works", "pi-ai"), join(codingAgent, "node_modules", "typebox")]
+      .map((path) => mkdir(path, { recursive: true })));
+    await writeFile(entry, "#!/usr/bin/env node\n", { mode: 0o700 });
+    await symlink(entry, join(bin, "pi"));
+    await writeFile(join(codingAgent, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/bundle/cli.js" } }));
+    await writeFile(join(codingAgent, "dist", "package.json"), JSON.stringify({ name: "unrelated" }));
+    await writeFile(join(codingAgent, "node_modules", "@earendil-works", "pi-ai", "package.json"), JSON.stringify({ name: "@earendil-works/pi-ai" }));
+    await writeFile(join(codingAgent, "node_modules", "typebox", "package.json"), JSON.stringify({ name: "typebox" }));
+    process.env.PATH = `${bin}${delimiter}${originalPath ?? ""}`;
+    assert.equal(locatePiPackages().codingAgent, realpathSync(codingAgent));
+    assert.equal(piCliEntry(), realpathSync(entry));
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    await rm(prefix, { recursive: true, force: true });
+  }
+});
+
 test("an npm shim resolves even though it is not a shebang script", async () => {
   const prefix = await mkdtemp(join(tmpdir(), "pi-installation-shim-"));
   const codingAgent = join(prefix, "node_modules", "@earendil-works", "pi-coding-agent");
@@ -58,6 +83,23 @@ test("an npm shim resolves even though it is not a shebang script", async () => 
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
     await rm(prefix, { recursive: true, force: true });
+  }
+});
+
+test("live launches disable ambient resources while retaining explicit package and tool selection", () => {
+  const original = process.env.PI_CLAUDE_CODE_PROVIDER_PI_BIN;
+  try {
+    // Use an existing executable; this test checks argv without launching Pi.
+    process.env.PI_CLAUDE_CODE_PROVIDER_PI_BIN = process.execPath;
+    const launch = livePiLaunch(["-e", "/fixture/provider", "--tools", "read,write"]);
+    assert.equal(launch.command, process.execPath);
+    assert.deepEqual(launch.args, [
+      "--no-extensions", "--no-skills", "--no-context-files", "--no-prompt-templates",
+      "-e", "/fixture/provider", "--tools", "read,write",
+    ]);
+  } finally {
+    if (original === undefined) delete process.env.PI_CLAUDE_CODE_PROVIDER_PI_BIN;
+    else process.env.PI_CLAUDE_CODE_PROVIDER_PI_BIN = original;
   }
 });
 


### PR DESCRIPTION
## Background

On Apple Silicon macOS, the provider displays this warning on every startup:

```text
Warning: [pi-claude-code-provider] Apple Silicon macOS is a compatibility candidate;
deterministic CI passes, but subscription-consuming live validation is pending
```

This PR adds live validation evidence and marks `darwin-arm64` as verified, removing this platform warning.

Completing that validation exposed two harness assumptions unrelated to the transport: `default` was pinned to Sonnet even though Claude Code chooses the account's runtime default, and Pi automatically loaded personal resources into the test prompt.

This preserves Claude Code's [default model selection](https://code.claude.com/docs/en/model-config#default-model-setting) rather than forcing another model to satisfy the test.

## Changes

- Give paid validation a temporary Pi agent directory and disable automatic resource discovery. Personal skills stay in place, and the provider's prompt-size bound remains unchanged.
- Require a concrete Claude identity for `default` while retaining exact identity checks for explicit aliases and existing capacity, cleanup, and leak checks. Apply Opus's existing Pro context safeguard to `default`.
- Recognize the `dist/bundle/cli.js` npm layout and validate candidate package identities. The verified Pi version remains 0.84.2.
- Mark `darwin-arm64` verified and document the tested versions and live coverage.

## Verification

Environment: macOS 26.5 arm64, Node 25.9.0, Pi 0.84.2, Claude Code 2.1.260.

- Source-policy and TypeScript checks pass.
- Deterministic tests pass: 170 passed, 5 platform skips (`node --import ./test/support/register-pi-loader.js --test --test-concurrency=1 test/unit/*.test.js`).
- Package metadata, content, and secret checks pass; `git diff --check` passes.
- Live text, tools, images, isolation, recovery, Unicode, history, and web search checks pass.
- Prompt-cache reuse reaches 99.3% and 99.0% on subsequent turns.
- Tool bridge round trips pass with npm Pi and the macOS arm64 standalone build.
- All 20 blocking model/effort combinations pass, including account-selected `default` at all five effort levels.

Default parallel execution can hit the unchanged cleanup test's 1-second deadline on this host. Focused and full serial runs pass without increasing the deadline.

AI assistance: `openai-codex/gpt-6-astra`, Pi 0.85.0, medium thinking.
