### PR TITLE
Allow explicit acknowledgement of startup platform advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Claude Code's public headless protocol cannot accept arbitrary historical assist
 
 | Variable | Purpose |
 | --- | --- |
+| `PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM` | Exact platform/architecture (for example `darwin/arm64`) whose startup compatibility advisory you acknowledge and wish to hide. Unset by default. Does not mark the platform verified or hide doctor/report metadata, authentication errors, rate-limit notices, or runtime validation failures. |
 | `PI_CLAUDE_CODE_PROVIDER_PATH` | Override the `claude` executable path. |
 | `PI_CLAUDE_CODE_PROVIDER_METRICS_LOG` | Append content-free request and search metrics as JSONL. |
 | `PI_CLAUDE_CODE_PROVIDER_IDLE_TIMEOUT_MS` | Override the five-minute protocol-idle timeout with positive milliseconds. |
@@ -91,7 +92,7 @@ Pi packages run with the user's permissions; review the source before installati
 
 - **Provider missing:** run the doctor, correct the reported problem, then run `/reload`.
 - **Authentication rejected:** run `claude auth status` and log in with an eligible first-party subscription.
-- **Compatibility warning:** compare the installed versions with [DEVELOPING.md](DEVELOPING.md#compatibility-baseline).
+- **Compatibility warning:** compare the installed versions with [DEVELOPING.md](DEVELOPING.md#compatibility-baseline). To acknowledge an unverified platform without changing its verification status, launch with e.g. `PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM=darwin/arm64 pi`. This hides that platform's startup advisory only; unset the variable to restore it. It is not evidence that live validation passed.
 - **Search unavailable:** allow `pi_claude_code_provider_web_search` in Pi's tool filters and check for a name collision.
 - **`pi auth check` reports `provider_not_found`:** that command does not load extensions, so it cannot see any extension-registered provider. Use `/pi-claude-code-provider-doctor` to check readiness.
 - **Tool proposals never arrive, or requests fail with `mcp_startup`:** run `/pi-claude-code-provider-doctor`. It reports the exact bridge argument vector and whether the handshake completed. Raising `PI_CLAUDE_CODE_PROVIDER_MCP_READY_TIMEOUT_MS` only helps when the handshake succeeds but is slow.

--- a/extensions/pi-claude-code-provider.ts
+++ b/extensions/pi-claude-code-provider.ts
@@ -7,7 +7,7 @@ import { Type } from "typebox";
 import { inspectClaudeInstallation } from "../src/auth.ts";
 import { providerModelsForSubscription } from "../src/catalog.ts";
 import { bridgeArgv } from "../src/claude-args.ts";
-import { VERIFIED_VERSIONS, platformStatus, versionStatus } from "../src/compatibility.ts";
+import { VERIFIED_VERSIONS, platformStatus, startupPlatformWarning, versionStatus } from "../src/compatibility.ts";
 import { writeDiagnosticReport } from "../src/diagnostics.ts";
 import { errorText, normalizeClaudeOverflow } from "../src/errors.ts";
 import { formatDoctorSummary, probeBridge } from "../src/doctor.ts";
@@ -57,7 +57,8 @@ export default async function piClaudeCodeProvider(pi: ExtensionAPI): Promise<vo
     // The provider starts a process per tool round-trip; session scope prevents
     // Claude's repeated notice from surfacing throughout one Pi turn.
     activeRateLimitNotify = createRateLimitNotifier((message) => ctx.ui.notify(message, "warning"));
-    if (currentPlatform.warning) ctx.ui.notify(`${NOTICE_PREFIX} ${currentPlatform.warning}`, "warning");
+    const platformWarning = startupPlatformWarning(currentPlatform);
+    if (platformWarning) ctx.ui.notify(`${NOTICE_PREFIX} ${platformWarning}`, "warning");
     if (searchRegistrationAttempted) return;
     searchRegistrationAttempted = true;
     registerWebSearchTool(

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -87,6 +87,16 @@ export function platformStatus(
   };
 }
 
+/** Dismiss only the startup advisory for an explicitly acknowledged platform.
+ * Doctor/report metadata and runtime validation remain unchanged.
+ */
+export function startupPlatformWarning(
+  status: VersionStatus,
+  acknowledgedPlatform: string | undefined = process.env.PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM,
+): string | undefined {
+  return acknowledgedPlatform === status.current ? undefined : status.warning;
+}
+
 /** Return verification metadata; mismatches never block execution by themselves. */
 export function versionStatus(component: string, current: string, verified: string): VersionStatus {
   return {

--- a/test/unit/compatibility.test.js
+++ b/test/unit/compatibility.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { EXPECTED_MODEL_RESOLUTIONS, VERIFIED_VERSIONS, platformStatus, versionStatus } from "../../src/compatibility.ts";
+import { EXPECTED_MODEL_RESOLUTIONS, VERIFIED_VERSIONS, platformStatus, startupPlatformWarning, versionStatus } from "../../src/compatibility.ts";
 
 test("verified versions report verified status without a warning", () => {
   const status = versionStatus("Pi", VERIFIED_VERSIONS.pi, VERIFIED_VERSIONS.pi);
@@ -20,6 +20,18 @@ test("untested versions remain identifiable without a startup warning", () => {
   assert.equal(status.current, "99.0.0");
   assert.equal(status.verified, VERIFIED_VERSIONS.claudeCode);
   assert.equal(status.warning, undefined);
+});
+
+test("startup platform acknowledgement is exact and preserves diagnostic metadata", () => {
+  const status = Object.freeze(platformStatus("darwin", "arm64"));
+  for (const value of ["", "1", "true", "*", "darwin/x64", "darwin/arm64 "]) {
+    assert.equal(startupPlatformWarning(status, value), status.warning);
+  }
+  assert.equal(startupPlatformWarning(status, "darwin/arm64"), undefined);
+  assert.equal(status.isVerified, false);
+  assert.match(status.warning, /live validation is pending/);
+  assert.equal(startupPlatformWarning(platformStatus("linux", "arm64"), "darwin/arm64"), platformStatus("linux", "arm64").warning);
+  assert.equal(startupPlatformWarning(platformStatus("win32", "x64"), ""), undefined);
 });
 
 test("reports verified and candidate platforms accurately", () => {

--- a/test/unit/extension.test.js
+++ b/test/unit/extension.test.js
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import initializePiClaudeCodeProvider from "../../extensions/pi-claude-code-provider.ts";
-import { VERIFIED_VERSIONS } from "../../src/compatibility.ts";
+import { VERIFIED_VERSIONS, platformStatus } from "../../src/compatibility.ts";
 import { CLAUDE_HEADLESS_HELP, ELIGIBLE_CLAUDE_AUTH } from "../support/claude-fixture.js";
 import { nodeFixtureSource } from "../support/node-fixture.js";
 
@@ -58,6 +58,38 @@ else {
     await chmod(executable, 0o700);
     return { directory, executable };
 }
+
+test("platform acknowledgement hides only the startup advisory and leaves doctor truthful", async (t) => {
+    const status = platformStatus();
+    if (!status.warning) return t.skip("host has no platform advisory");
+    const { directory, executable } = await createFakeClaude();
+    const originalPath = process.env.PI_CLAUDE_CODE_PROVIDER_PATH;
+    const originalAcknowledgement = process.env.PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM;
+    process.env.PI_CLAUDE_CODE_PROVIDER_PATH = executable;
+    try {
+        const pi = fakePi();
+        await piClaudeCodeProvider(pi.api);
+        const notices = [];
+        const ctx = { ui: { notify(message, level) { notices.push({ message, level }); } } };
+        delete process.env.PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM;
+        pi.handlers.get("session_start")[0]({}, ctx);
+        assert.ok(notices.some(({ message }) => message.includes(status.warning)));
+        await pi.handlers.get("session_shutdown")[0]({}, {});
+        notices.length = 0;
+        process.env.PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM = status.current;
+        pi.handlers.get("session_start")[0]({}, ctx);
+        assert.equal(notices.some(({ message }) => message.includes(status.warning)), false);
+        await pi.commands.get("pi-claude-code-provider-doctor").handler("", ctx);
+        assert.ok(notices.some(({ message }) => message.includes(`Platform ${status.current} (unverified;`)));
+        await pi.handlers.get("session_shutdown")[0]({}, {});
+    } finally {
+        if (originalPath === undefined) delete process.env.PI_CLAUDE_CODE_PROVIDER_PATH;
+        else process.env.PI_CLAUDE_CODE_PROVIDER_PATH = originalPath;
+        if (originalAcknowledgement === undefined) delete process.env.PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM;
+        else process.env.PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM = originalAcknowledgement;
+        await rm(directory, { recursive: true, force: true });
+    }
+});
 
 test("routes rate-limit warnings to the active Pi UI without requiring one", async () => {
     const { directory, executable } = await createFakeClaude("ok", { rateLimitInfo: {


### PR DESCRIPTION
## Summary
Allow users to acknowledge a known startup platform advisory without claiming the platform is verified:

```sh
PI_CLAUDE_CODE_PROVIDER_ACKNOWLEDGED_PLATFORM=darwin/arm64 pi
```

- Opt-in; unchanged default behavior.
- Exact platform/architecture match (no wildcard or boolean suppression).
- Only the startup platform notification is affected. Doctor/report metadata, verified baselines, runtime validation, authentication errors, and rate-limit notices remain unchanged.
- Documents how to restore the notice by unsetting the variable.

## Motivation and scope
The recurring Apple Silicon advisory motivated this change. A local smoke test is not sufficient evidence to promote an entire platform to verified, so this PR deliberately makes no baseline changes. Acknowledgement is a user preference, not validation evidence.

## Tests and review
- `npm run setup:dev`
- `npm run check` (including strict typecheck): passed.
- `npm test`: 166 passed, 5 skipped, 0 failed on Apple Silicon using an isolated npm Pi 0.84.2 baseline and Node 26.8.1.
- Unit test covers exact matching, invalid acknowledgement values, cross-platform mismatch, and unchanged verification metadata.
- Extension integration test checks default notice, acknowledged notice suppression, and doctor continuing to report the platform as unverified.
- `git diff --check`: passed.

The initial test run using the local Pi 0.85.0 installation could not import its missing `@earendil-works/pi-server` dependency. Validation was rerun successfully using an isolated installation of the documented Pi 0.84.2 baseline; no unrelated package-resolution changes are included.

## Limited live evidence (not a release gate)
Separately, the installed provider 0.1.4 was smoke-tested on darwin/arm64 with Pi 0.85.0, Claude Code 2.1.261 and a Pro subscription. Bridge initialize/tools-list succeeded; Haiku text and a read round-trip succeeded. The repeated read test captured structured execution-start/execution-end events, a random file token in the successful tool result, and that token in the final answer. Response metadata identified `claude-haiku-4-5-20251001`.

Those smoke checks concern the installed provider, not a full release validation of this PR. No full paid release matrix, other model aliases, image/cancellation/search live suite, or standalone Mac gate was run. They are not grounds for changing platform verification status.

## AI assistance disclosure
Implementation, review and PR preparation were AI-assisted using model `gpt-6-astra`, provider `openai-codex`, Pi harness 0.85.0, thinking level `minimal` (as reported by the local session environment). Earlier exploratory troubleshooting in the same conversation was also AI-assisted; the current session cannot reliably attribute every earlier turn's model/version.
